### PR TITLE
v2.0.0.beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /spec/support/config.yml
 /tmp/
 !/tmp/.keep
+/.ruby-version
 
 # rspec failure tracking
 .rspec_status

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
-sudo: false
 language: ruby
+services:
+  - mysql
+  - postgresql
 rvm:
-  - 2.2.9
-before_install: gem install bundler -v 1.17.2
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
+before_install:
+  - gem install bundler -v 1.17.3
+before_script:
+  - bin/setup
+

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in database_cleaner-sequel.gemspec
 gemspec
 
-gem "database_cleaner", path: "../.."
+gem "database_cleaner-core", github: "DatabaseCleaner/database_cleaner", branch: "v2.0.0.beta"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,51 +1,51 @@
-PATH
-  remote: ../..
+GIT
+  remote: https://github.com/DatabaseCleaner/database_cleaner
+  revision: 5ab507c613764c36b007a796d5195cc9b875090b
+  branch: v2.0.0.beta
   specs:
-    database_cleaner (1.8.0)
+    database_cleaner-core (2.0.0.beta)
 
 PATH
   remote: .
   specs:
-    database_cleaner-sequel (1.8.0)
-      database_cleaner (~> 1.8.0)
+    database_cleaner-sequel (2.0.0.beta)
+      database_cleaner-core (= 2.0.0.beta)
       sequel
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
-    mysql (2.9.1)
-    mysql2 (0.3.18)
-    pg (0.18.2)
-    rake (10.4.2)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    mysql2 (0.5.3)
+    pg (1.2.2)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    sequel (5.28.0)
-    sqlite3 (1.3.10)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
+    sequel (5.29.0)
+    sqlite3 (1.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
-  database_cleaner!
+  bundler
+  database_cleaner-core!
   database_cleaner-sequel!
-  mysql (~> 2.9.1)
   mysql2
   pg
-  rake (~> 10.0)
-  rspec (~> 3.0)
+  rake
+  rspec
   sqlite3
 
 BUNDLED WITH

--- a/database_cleaner-sequel.gemspec
+++ b/database_cleaner-sequel.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "database_cleaner/sequel/version"
@@ -14,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/DatabaseCleaner/database_cleaner-sequel"
   spec.license       = "MIT"
 
-  spec.add_dependency "database_cleaner", "~> 1.8.0"
+  spec.add_dependency "database_cleaner-core", "2.0.0.beta"
   spec.add_dependency "sequel"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
@@ -24,12 +23,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
 
-  spec.add_development_dependency 'mysql', '~> 2.9.1'
-  spec.add_development_dependency 'mysql2'
-  spec.add_development_dependency 'pg'
+  spec.add_development_dependency "mysql2"
+  spec.add_development_dependency "pg"
   spec.add_development_dependency "sqlite3"
 end

--- a/database_cleaner-sequel.gemspec
+++ b/database_cleaner-sequel.gemspec
@@ -5,7 +5,7 @@ require "database_cleaner/sequel/version"
 Gem::Specification.new do |spec|
   spec.name          = "database_cleaner-sequel"
   spec.version       = DatabaseCleaner::Sequel::VERSION
-  spec.authors       = ["Ernesto Tagwerker"]
+  spec.authors       = ["Ernesto Tagwerker", "Micah Geisel"]
   spec.email         = ["ernesto@ombulabs.com"]
 
   spec.summary       = "Strategies for cleaning databases using Sequel. Can be used to ensure a clean state for testing."

--- a/lib/database_cleaner/sequel.rb
+++ b/lib/database_cleaner/sequel.rb
@@ -1,5 +1,5 @@
 require "database_cleaner/sequel/version"
-require "database_cleaner"
+require "database_cleaner/core"
 require "database_cleaner/sequel/truncation"
 require "database_cleaner/sequel/transaction"
 require "database_cleaner/sequel/deletion"

--- a/lib/database_cleaner/sequel/version.rb
+++ b/lib/database_cleaner/sequel/version.rb
@@ -1,5 +1,5 @@
 module DatabaseCleaner
   module Sequel
-    VERSION = "1.8.0"
+    VERSION = "2.0.0.beta"
   end
 end

--- a/spec/support/sample.config.yml
+++ b/spec/support/sample.config.yml
@@ -1,12 +1,3 @@
-mysql:
-  adapter: mysql
-  database: database_cleaner_test
-  username: root
-  password:
-  host: 127.0.0.1
-  port: 3306
-  encoding: utf8
-
 mysql2:
   adapter: mysql2
   database: database_cleaner_test
@@ -31,4 +22,3 @@ sqlite3:
   pool: 5
   timeout: 5000
   encoding: utf8
-


### PR DESCRIPTION
This PR gets everything in place for a v2.0.0.beta release. Specifically:

1. Wire up to the database_cleaner-core v2.0.0.beta branch on Github
1. Support Ruby versions 2.4 through 2.7
1. Decision to support only latest version of Sequel, based off of Sequel's rather linear release history and extremely broad support. Is this the correct decision?