### PR TITLE
Use auto savepoint for transactions

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
-set -vx
+
+NAME=$0
+DOCKER=NO
+
+usage() {
+  cat <<EOF
+Usage:
+  $NAME
+
+OPTIONS
+  -d|--docker  copy example config that works with docker-composed test
+               databases, copy  default otherwise.
+  -h|--help    display this message and exit.
+EOF
+}
+
+while [[ $# -gt 0 ]]
+do
+
+opt="$1"
+case $opt in
+  -d|--docker)
+    DOCKER=YES
+    shift
+    ;;
+  -h|--help)
+    usage
+    exit
+    ;;
+esac
+done
 
 bundle check || bundle install
-cp spec/support/sample.config.yml spec/support/config.yml
 
+if [[ $DOCKER = "YES" ]]
+then
+  cp spec/support/sample-docker.config.yml spec/support/config.yml
+  echo "Run \`docker-compose up\` to setup databases"
+else
+  cp spec/support/sample.config.yml spec/support/config.yml
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.1'
+
+services:
+  mysql:
+    image: mysql:8
+    ports:
+      - 3307:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: root-password
+      MYSQL_DATABASE: database_cleaner_test
+      MYSQL_USER: database_cleaner
+      MYSQL_PASSWORD: database_cleaner
+    volumes:
+      - mydata:/var/lib/mysql
+
+  postgres:
+    image: postgres:12
+    ports:
+      - 5433:5432
+    environment:
+      POSTGRES_DB: database_cleaner_test
+      POSTGRES_USER: database_cleaner
+      POSTGRES_PASSWORD: database_cleaner
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  mydata:
+  pgdata:

--- a/lib/database_cleaner/sequel/transaction.rb
+++ b/lib/database_cleaner/sequel/transaction.rb
@@ -19,7 +19,7 @@ module DatabaseCleaner
         @fibers ||= []
         db = self.db
         f = Fiber.new do
-          db.transaction(:rollback => :always, :savepoint => true) do
+          db.transaction(:rollback => :always, :savepoint => true, :auto_savepoint => true) do
             Fiber.yield
           end
         end
@@ -33,7 +33,7 @@ module DatabaseCleaner
       end
 
       def cleaning
-        self.db.transaction(:rollback => :always, :savepoint => true) { yield }
+        self.db.transaction(:rollback => :always, :savepoint => true, :auto_savepoint => true) { yield }
       end
     end
   end

--- a/spec/database_cleaner/sequel/base_spec.rb
+++ b/spec/database_cleaner/sequel/base_spec.rb
@@ -17,9 +17,9 @@ module DatabaseCleaner
     end
 
     RSpec.describe ExampleStrategy do
-      it_should_behave_like "a generic strategy"
       it { is_expected.to respond_to(:db)  }
       it { is_expected.to respond_to(:db=) }
+      it { is_expected.to respond_to(:cleaning) }
 
       it "should store my desired db" do
         subject.db = :my_db

--- a/spec/database_cleaner/sequel/deletion_spec.rb
+++ b/spec/database_cleaner/sequel/deletion_spec.rb
@@ -5,7 +5,7 @@ require 'support/sequel_helper'
 module DatabaseCleaner
   module Sequel
     RSpec.describe Deletion do
-      it_should_behave_like "a generic strategy"
+      it_should_behave_like "a database_cleaner strategy"
 
       SequelHelper.with_all_dbs do |helper|
         context "using a #{helper.db} connection" do

--- a/spec/database_cleaner/sequel/transaction_spec.rb
+++ b/spec/database_cleaner/sequel/transaction_spec.rb
@@ -8,6 +8,85 @@ module DatabaseCleaner
       it_should_behave_like "a generic strategy"
       it_should_behave_like "a generic transaction strategy"
 
+      SequelHelper.with_all_dbs do |helper|
+        context "using a #{helper.db} connection" do
+          around do |example|
+            helper.setup
+            example.run
+            helper.teardown
+          end
+
+          let(:connection) { helper.connection }
+
+          before { subject.db = connection }
+
+          context "cleaning" do
+            it "should clean database" do
+              subject.cleaning do
+                connection[:users].insert
+                expect(connection[:users].count).to eq(1)
+              end
+
+              expect(connection[:users]).to be_empty
+            end
+
+            it "should work with nested transaction" do
+              subject.cleaning do
+                begin
+                  connection.transaction do
+                    connection[:users].insert
+                    connection[:users].insert
+
+                    expect(connection[:users].count).to eq(2)
+                    raise ::Sequel::Rollback
+                  end
+                rescue
+                end
+
+                connection[:users].insert
+                expect(connection[:users].count).to eq(1)
+              end
+
+              expect(connection[:users]).to be_empty
+            end
+          end
+
+          context "start/clean" do
+            it "should clean database" do
+              subject.start
+
+              connection[:users].insert
+              expect(connection[:users].count).to eq(1)
+
+              subject.clean
+
+              expect(connection[:users]).to be_empty
+            end
+
+            it "should work with nested transaction" do
+              subject.start
+              begin
+                connection.transaction do
+                  connection[:users].insert
+                  connection[:users].insert
+
+                  expect(connection[:users].count).to eq(2)
+                  raise ::Sequel::Rollback
+                end
+              rescue
+              end
+
+              connection[:users].insert
+              expect(connection[:users].count).to eq(1)
+
+              subject.clean
+
+              expect(connection[:users]).to be_empty
+            end
+          end
+        end
+      end
+
       describe "start" do
         it "should start a transaction"
       end

--- a/spec/database_cleaner/sequel/transaction_spec.rb
+++ b/spec/database_cleaner/sequel/transaction_spec.rb
@@ -5,8 +5,7 @@ require 'support/sequel_helper'
 module DatabaseCleaner
   module Sequel
     RSpec.describe Transaction do
-      it_should_behave_like "a generic strategy"
-      it_should_behave_like "a generic transaction strategy"
+      it_should_behave_like "a database_cleaner strategy"
 
       SequelHelper.with_all_dbs do |helper|
         context "using a #{helper.db} connection" do

--- a/spec/database_cleaner/sequel/truncation_spec.rb
+++ b/spec/database_cleaner/sequel/truncation_spec.rb
@@ -5,8 +5,7 @@ require 'support/sequel_helper'
 module DatabaseCleaner
   module Sequel
     RSpec.describe Truncation do
-      it_should_behave_like "a generic strategy"
-      it_should_behave_like "a generic truncation strategy"
+      it_should_behave_like "a database_cleaner strategy"
 
       SequelHelper.with_all_dbs do |helper|
         context "using a #{helper.db} connection" do

--- a/spec/support/sample-docker.config.yml
+++ b/spec/support/sample-docker.config.yml
@@ -1,0 +1,25 @@
+mysql2:
+  adapter: mysql2
+  database: database_cleaner_test
+  username: database_cleaner
+  password: database_cleaner
+  host: 127.0.0.1
+  port: 3307
+  encoding: utf8
+
+postgres:
+  adapter: postgresql
+  database: database_cleaner_test
+  username: database_cleaner
+  password: database_cleaner
+  host: 127.0.0.1
+  port: 5433
+  encoding: unicode
+  template: template0
+
+sqlite3:
+  adapter: sqlite3
+  database: tmp/database_cleaner_test.sqlite3
+  pool: 5
+  timeout: 5000
+  encoding: utf8


### PR DESCRIPTION
Port of original PR to main `database_cleaner` repo: https://github.com/DatabaseCleaner/database_cleaner/pull/577

Adding `auto_savepoint: true` to transaction call makes inner transactions to use savepoint, therefore they can be rolled back independently. 