### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ DatabaseCleaner[:sequel].db = Sequel.connect(uri)
 DatabaseCleaner[:sequel].db = :default
 
 # Multiple Sequel databases can be specified:
-DatabaseCleaner[:sequel, connection: :default]
-DatabaseCleaner[:sequel, connection: Sequel.connect(uri)]
+DatabaseCleaner[:sequel, db: :default]
+DatabaseCleaner[:sequel, db: Sequel.connect(uri)]
 ```
 ## COPYRIGHT
 


### PR DESCRIPTION
Rename of `:connection` configuration option to `:db`: https://github.com/DatabaseCleaner/database_cleaner/pull/650
Probably worth mentioning in release notes for the 2.0.0.