### PR TITLE
Truncation.new: take Hash as argument instead of named parameters

### DIFF
--- a/lib/database_cleaner/sequel/truncation.rb
+++ b/lib/database_cleaner/sequel/truncation.rb
@@ -3,10 +3,10 @@ require 'database_cleaner/sequel/base'
 module DatabaseCleaner
   module Sequel
     class Truncation < Base
-      def initialize only: [], except: [], pre_count: false
-        @only = only
-        @except = except
-        @pre_count = pre_count
+      def initialize(opts)
+        @only = opts[:only] || []
+        @except = opts[:except] || []
+        @pre_count = opts[:pre_count] || false
       end
 
       def start


### PR DESCRIPTION
to maintain Ruby 3 compatibility with database_cleaner's calling convention

Fixes #19 