### PR TITLE
Bugfix: Allow empty options for truncation strategy

### DIFF
--- a/lib/database_cleaner/sequel/truncation.rb
+++ b/lib/database_cleaner/sequel/truncation.rb
@@ -3,7 +3,7 @@ require 'database_cleaner/sequel/base'
 module DatabaseCleaner
   module Sequel
     class Truncation < Base
-      def initialize(opts)
+      def initialize(opts = {})
         @only = opts[:only] || []
         @except = opts[:except] || []
         @pre_count = opts[:pre_count] || false


### PR DESCRIPTION
According to the [README](https://github.com/DatabaseCleaner/database_cleaner#rspec-example), it should be possible to call `DatabaseCleaner.clean_with(:truncation)`. With the change introduced in https://github.com/DatabaseCleaner/database_cleaner-sequel/pull/20, this was broken. This PR restores functionality with the simplest possible fix.

IMO 2.0.1 needs to be yanked and this fix needs to be released as 2.0.2 ASAP, so people don't run into breaking builds.

Further improvements could be made, e.g. to use the same input validation as the database_cleaner-active_record gem uses (https://github.com/DatabaseCleaner/database_cleaner-active_record/blob/main/lib/database_cleaner/active_record/truncation.rb#L9-L11). If desirable, the overall DatabaseCleaner architecture could be revised to e.g. use a declarative approach for options. I could very well imagine an approach using dry-initializer that would be quite pretty:

``` ruby
class Truncation
  extend  Dry::Initializer

  option :only, default: []
  option :except, default: []
  option :pre_count, default: false
end
```