### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Pivot from Travis CI to GitHub Actions for continuous integration. ([#30](https://github.com/DatabaseCleaner/database_cleaner-sequel/pull/30))
+
+## [2.0.2] - 2022-03-08
+
+### Fixed
+
+- Allow empty options for the truncation strategy. ([#26](https://github.com/DatabaseCleaner/database_cleaner-sequel/pull/26))
+
+## [2.0.1] - 2022-03-01
+
+### Fixed
+
+- `Truncation.new` now takes a `Hash` as an argument instead of named parameters, to maintain Ruby 3 compatibility with `database_cleaner`'s calling convention. ([#20](https://github.com/DatabaseCleaner/database_cleaner-sequel/pull/20))
+- Rename the `:connection` configuration option to `:db` in the README.
+
+## [2.0.0] - 2021-01-31
+
+### Added
+
+- Add a `docker-compose.yml` for test database setup. ([#11](https://github.com/DatabaseCleaner/database_cleaner-sequel/pull/11))
+- Use auto savepoints for transactions.
+
+### Changed
+
+- Split `database_cleaner-sequel` out of the main `database_cleaner` repository into its own gem.
+- Update to the new adapter API from `database_cleaner` core.
+- Requiring this gem must now explicitly configure `DatabaseCleaner` to use it, since autodetection has been removed.
+- Drop support for Ruby 2.4, which reached end of life on 2020-03-31.
+- Drop support for the `mysql` (mysql1) adapter.
+- Upgrade dependencies and drop support for older Rubies.
+
+## [2.0.0.beta] - 2020-05-30
+
+### Changed
+
+- Begin development on the standalone `2.0.0` line of the gem.
+
+[Unreleased]: https://github.com/DatabaseCleaner/database_cleaner-sequel/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/DatabaseCleaner/database_cleaner-sequel/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/DatabaseCleaner/database_cleaner-sequel/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/DatabaseCleaner/database_cleaner-sequel/compare/v2.0.0.beta...v2.0.0
+[2.0.0.beta]: https://github.com/DatabaseCleaner/database_cleaner-sequel/releases/tag/v2.0.0.beta


### PR DESCRIPTION
## What

Adds a `CHANGELOG.md` to the repo, closing #25.

## Why

The issue asks for a changelog so it's easier to track what changed between released versions. Until now you had to read through git history or compare tags to figure out what shipped.

## How

The changelog follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantic Versioning](https://semver.org/). It documents the standalone gem's `2.0.x` line (this repo was split out of the main `database_cleaner` repo at `v2.0.0.beta`), reconstructed from tags and commit history:

- `Unreleased` (CI pivot to GitHub Actions)
- `2.0.2`, `2.0.1`, `2.0.0`, `2.0.0.beta`

Each entry is grouped under Added / Changed / Fixed and links to the relevant PR where one exists. Version headings link to GitHub compare views.

## Notes

Opening as a draft. A couple of things worth a second look:

- I scoped the changelog to the `2.0.x` line since that's when this gem became standalone. Should the older `0.x`/`1.x` tags (inherited from the combined repo) be included too, or is starting at `2.0.0.beta` the right call?
- Going forward, would you like an `Unreleased` section maintained as part of the release process, or do you prefer generating entries at release time?

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)